### PR TITLE
Suggest using npm "version" script to update changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,14 @@ To fully customize the tool, please checkout [conventional-changelog](https://gi
 
 The reason why you should commit and tag after `conventionalChangelog` is that the CHANGELOG should be included in the new release, hence `gitRawCommitsOpts.from` defaults to the latest semver tag.
 
-If you use `npm version`, it auto tags immediately after changing the version in package.json. In such case, you might want to specify the version manually and generate the changelog before `npm version`.
+If you use `npm version`, it auto tags immediately after changing the version in package.json. In such case, you might want to specify the version manually and generate the changelog before `npm version`. Alternatively, if you add a [`"version"` script](https://docs.npmjs.com/cli/version) in your `package.json` that updates your changelog, you can use `npm version` and have the updated changelog included in the commit+tag that npm creates for you, e.g.:
+```javascript
+// package.json
+"scripts": {
+  // ...
+  "version": "conventionalChangelog && git add CHANGELOG.md" // the updated changelog will now be part of the commit and tag that `npm version` generates
+}
+```
 
 Please use this [gist](https://gist.github.com/stevemao/280ef22ee861323993a0) to make a release or change it to your needs.
 


### PR DESCRIPTION
Update the readme to mention that the developer can add a `"version"` script to their npm scripts in `package.json` to make it so that the `npm version` command automatically updates the changelog as it also bumps the version and commits+tags the change. As mentioned in the [`npm version` script docs](https://docs.npmjs.com/cli/version), any files added using `git add` will be included in the tagged version-bump commit:

> Run the version script. These scripts have access to the new version in package.json (so they can incorporate it into file headers in generated files for example). Again, scripts should explicitly add generated files to the commit using git add.
